### PR TITLE
Chat TUI: suppress markdown delimiters; preserve TextMate scopes

### DIFF
--- a/docs-src/lib/chat_tui/renderer2.doc.md
+++ b/docs-src/lib/chat_tui/renderer2.doc.md
@@ -79,6 +79,14 @@
  - Paragraphs — A message is split on hard newlines into paragraphs. Each
    paragraph is wrapped to the available width (after the prefix) using
    display-cell width as measured by Notty.
+ - Inline markdown delimiters — When rendering a markdown paragraph, the
+   renderer suppresses the delimiter marker characters for:
+   - bold (`**...**` and `__...__`)
+   - italics (`*...*` and `_..._`)
+   - inline code (backticks, including multi-backtick spans)
+
+   The enclosed text remains styled (bold/italic/inline-code) and other
+   punctuation remains visible (for example list bullets are unaffected).
  - Fenced code blocks — Detected by `Chat_tui.Markdown_fences.split` and
    rendered with `Chat_tui.Highlight_tm_engine`. A simple width-bucket cache
    keyed by (`role-class`, `lang`, `md5(lang^NUL^code)`, `width-bucket`) avoids
@@ -105,9 +113,10 @@
  - Geometry heuristics — Notty’s display width is heuristic (see its docs on
    Unicode geometry). East-Asian wide glyphs and some emoji may cause off-by-1
    wrapping on certain terminals.
- - Debug output — When markdown highlighting falls back in a specific branch,
-   a temporary `print_endline` may emit a line during rendering. This does not
-   affect display but can pollute logs; it will be removed in a follow-up.
+ - Grammar loading diagnostics — If a bundled TextMate grammar fails to load,
+   the registry initialisation may print a diagnostic to stdout. This is most
+   visible for optional grammars; markdown highlighting continues to work as
+   long as the markdown grammar loads successfully.
 
  ---
 

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,2 +1,0 @@
-(lang dune 3.21)
-(pkg enabled)

--- a/lib/chat_response/tool.ml
+++ b/lib/chat_response/tool.ml
@@ -239,7 +239,7 @@ let custom_fn ~env (c : CM.custom_tool) : Ochat_function.t =
   in
   (* timeout functioin eio *)
   let fp x =
-    try Eio.Time.with_timeout_exn (Eio.Stdenv.clock env) 60.0 (fun () -> fp x) with
+    try Eio.Time.with_timeout_exn (Eio.Stdenv.clock env) 180.0 (fun () -> fp x) with
     | Eio.Time.Timeout ->
       Printf.sprintf "timeout running command %s" (String.concat ~sep:" " x)
   in

--- a/lib/chat_tui/highlight_tm_engine.ml
+++ b/lib/chat_tui/highlight_tm_engine.ml
@@ -15,6 +15,12 @@ type t =
 
 type span = Notty.A.t * string
 
+type scoped_span =
+  { attr : Notty.A.t
+  ; text : string
+  ; scopes : string list
+  }
+
 type fallback_reason =
   | No_registry
   | Unknown_language of string
@@ -30,6 +36,11 @@ let fallback_spans ~text =
   String.split_lines text |> List.map ~f:(fun line -> [ Notty.A.empty, line ])
 ;;
 
+let fallback_scoped_spans ~text =
+  String.split_lines text
+  |> List.map ~f:(fun line -> [ { attr = Notty.A.empty; text = line; scopes = [] } ])
+;;
+
 let compress_adjacent (spans : span list) : span list =
   let rec loop acc = function
     | [] -> List.rev acc
@@ -42,56 +53,127 @@ let compress_adjacent (spans : span list) : span list =
   loop [] spans
 ;;
 
+let compress_adjacent_scoped (spans : scoped_span list) : scoped_span list =
+  let equal_scopes = List.equal String.equal in
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | ({ attr; text; scopes } as span) :: rest ->
+      (match acc with
+       | { attr = attr'; text = text'; scopes = scopes' } :: acc_rest
+         when phys_equal attr attr' && equal_scopes scopes scopes' ->
+         loop ({ attr; text = text' ^ text; scopes } :: acc_rest) rest
+       | _ -> loop (span :: acc) rest)
+  in
+  loop [] spans
+;;
+
+let scoped_spans_of_tokens ~theme ~line (tokens : TmLanguage.token list) : scoped_span list =
+  let line_len = String.length line in
+  let spans, _prev_end =
+    Stdlib.List.fold_left
+      (fun (acc_spans, prev_end) tok ->
+         let ending = TmLanguage.ending tok in
+         let start_i = Int.min prev_end line_len in
+         let end_i = Int.min ending line_len in
+         let text =
+           if end_i <= start_i
+           then ""
+           else String.sub line ~pos:start_i ~len:(end_i - start_i)
+         in
+         let scopes = TmLanguage.scopes tok in
+         let attr = Highlight_theme.attr_of_scopes theme ~scopes in
+         if String.is_empty text
+         then acc_spans, ending
+         else ({ attr; text; scopes } :: acc_spans), ending)
+      ([], 0)
+      tokens
+  in
+  List.rev spans
+;;
+
+let spans_of_tokens ~theme ~line (tokens : TmLanguage.token list) : span list =
+  let line_len = String.length line in
+  let spans, _prev_end =
+    Stdlib.List.fold_left
+      (fun (acc_spans, prev_end) tok ->
+         let ending = TmLanguage.ending tok in
+         let start_i = Int.min prev_end line_len in
+         let end_i = Int.min ending line_len in
+         let text =
+           if end_i <= start_i
+           then ""
+           else String.sub line ~pos:start_i ~len:(end_i - start_i)
+         in
+         let attr =
+           Highlight_theme.attr_of_scopes theme ~scopes:(TmLanguage.scopes tok)
+         in
+         if String.is_empty text then acc_spans, ending else (attr, text) :: acc_spans, ending)
+      ([], 0)
+      tokens
+  in
+  List.rev spans
+;;
+
+let tokenize_line reg grammar stack line =
+  let line_for_tm = line ^ "\n" in
+  Or_error.try_with (fun () -> TmLanguage.tokenize_exn reg grammar stack line_for_tm)
+;;
+
+let highlight_lines_with_scopes ~theme reg grammar ~text =
+  let lines = String.split_lines text in
+  let rec process acc stack = function
+    | [] -> Ok (List.rev acc)
+    | line :: rest ->
+      (match tokenize_line reg grammar stack line with
+       | Error _e -> Error ()
+       | Ok (tokens, stack') ->
+         let spans = scoped_spans_of_tokens ~theme ~line tokens |> compress_adjacent_scoped in
+         let spans =
+           if List.is_empty spans
+           then [ { attr = Notty.A.empty; text = line; scopes = [] } ]
+           else spans
+         in
+         process (spans :: acc) stack' rest)
+  in
+  process [] TmLanguage.empty lines
+;;
+
+let highlight_lines ~theme reg grammar ~text =
+  let lines = String.split_lines text in
+  let rec process acc stack = function
+    | [] -> Ok (List.rev acc)
+    | line :: rest ->
+      (match tokenize_line reg grammar stack line with
+       | Error _e -> Error ()
+       | Ok (tokens, stack') ->
+         let spans = spans_of_tokens ~theme ~line tokens |> compress_adjacent in
+         let spans = if List.is_empty spans then [ Notty.A.empty, line ] else spans in
+         process (spans :: acc) stack' rest)
+  in
+  process [] TmLanguage.empty lines
+;;
+
+let highlight_text_with_scopes (t : t) ~lang ~text =
+  match t.registry, lang with
+  | Some reg, Some l ->
+    (match Highlight_tm_loader.find_grammar_by_lang_tag reg l with
+     | None -> fallback_scoped_spans ~text
+     | Some grammar ->
+       (match highlight_lines_with_scopes ~theme:t.theme reg grammar ~text with
+        | Ok spans -> spans
+        | Error () -> fallback_scoped_spans ~text))
+  | _ -> fallback_scoped_spans ~text
+;;
+
 let highlight_text (t : t) ~lang ~text =
   match t.registry, lang with
   | Some reg, Some l ->
     (match Highlight_tm_loader.find_grammar_by_lang_tag reg l with
      | None -> fallback_spans ~text
      | Some grammar ->
-       let lines = String.split_lines text in
-       let rec process acc stack = function
-         | [] -> List.rev acc
-         | line :: rest ->
-           let line_for_tm = line ^ "\n" in
-           (match
-              Or_error.try_with (fun () ->
-                TmLanguage.tokenize_exn reg grammar stack line_for_tm)
-            with
-            | Error e ->
-              (* ignore @@ raise (Failure "Tokenization failed"); *)
-              ignore e;
-              process ([ Notty.A.empty, line ] :: acc) stack rest
-            | Ok (tokens, stack') ->
-              let line_len = String.length line in
-              let spans, _prev_end =
-                Stdlib.List.fold_left
-                  (fun (acc_spans, prev_end) tok ->
-                     let ending = TmLanguage.ending tok in
-                     let start_i = Int.min prev_end line_len in
-                     let end_i = Int.min ending line_len in
-                     let seg =
-                       if end_i <= start_i
-                       then ""
-                       else String.sub line ~pos:start_i ~len:(end_i - start_i)
-                     in
-                     let attr =
-                       Highlight_theme.attr_of_scopes
-                         t.theme
-                         ~scopes:(TmLanguage.scopes tok)
-                     in
-                     if String.length seg = 0
-                     then acc_spans, ending
-                     else (attr, seg) :: acc_spans, ending)
-                  ([], 0)
-                  tokens
-              in
-              let spans = compress_adjacent (List.rev spans) in
-              let spans =
-                if List.is_empty spans then [ Notty.A.empty, line ] else spans
-              in
-              process (spans :: acc) stack' rest)
-       in
-       process [] TmLanguage.empty lines)
+       (match highlight_lines ~theme:t.theme reg grammar ~text with
+        | Ok spans -> spans
+        | Error () -> fallback_spans ~text))
   | _ -> fallback_spans ~text
 ;;
 
@@ -102,7 +184,25 @@ let highlight_text_with_info (t : t) ~lang ~text : span list list * info =
   | Some reg, Some l ->
     (match Highlight_tm_loader.find_grammar_by_lang_tag reg l with
      | None -> fallback_spans ~text, { fallback = Some (Unknown_language l) }
-     | Some _grammar ->
-       let spans = highlight_text t ~lang ~text in
-       spans, { fallback = None })
+     | Some grammar ->
+       (match highlight_lines ~theme:t.theme reg grammar ~text with
+        | Ok spans -> spans, { fallback = None }
+        | Error () -> fallback_spans ~text, { fallback = Some Tokenize_error }))
+;;
+
+let highlight_text_with_scopes_with_info (t : t) ~lang ~text
+  : scoped_span list list * info
+  =
+  match t.registry, lang with
+  | None, _ -> fallback_scoped_spans ~text, { fallback = Some No_registry }
+  | Some _, None ->
+    fallback_scoped_spans ~text, { fallback = Some (Unknown_language "") }
+  | Some reg, Some l ->
+    (match Highlight_tm_loader.find_grammar_by_lang_tag reg l with
+     | None -> fallback_scoped_spans ~text, { fallback = Some (Unknown_language l) }
+     | Some grammar ->
+       (match highlight_lines_with_scopes ~theme:t.theme reg grammar ~text with
+        | Ok spans -> spans, { fallback = None }
+        | Error () ->
+          fallback_scoped_spans ~text, { fallback = Some Tokenize_error }))
 ;;

--- a/lib/chat_tui/highlight_tm_engine.mli
+++ b/lib/chat_tui/highlight_tm_engine.mli
@@ -41,6 +41,14 @@ type t
     [attr] is the display attribute to use when rendering that segment. *)
 type span = Notty.A.t * string
 
+(** A highlighted text fragment that also preserves the tokenizer scopes used
+    to compute [attr]. *)
+type scoped_span =
+  { attr : Notty.A.t
+  ; text : string
+  ; scopes : string list
+  }
+
 (** [create ~theme] creates a highlighter configured to use [theme] when
     mapping token scopes to attributes.
 
@@ -85,7 +93,8 @@ type fallback_reason =
 
     - [No_registry] — the highlighter did not carry a TextMate registry.
     - [Unknown_language l] — no grammar could be resolved for [l].
-    - [Tokenize_error] — tokenization failed for at least one line. *)
+    - [Tokenize_error] — tokenization failed for at least one line; the engine
+      falls back to plain spans for the whole input. *)
 
 type info =
   { fallback : fallback_reason option
@@ -134,6 +143,16 @@ type info =
     ]} *)
 val highlight_text : t -> lang:string option -> text:string -> span list list
 
+(** Like {!highlight_text} but preserves TextMate scope information per
+    segment. This is intended for callers that need to filter output based on
+    scopes (e.g. removing markdown delimiter punctuation) before collapsing to
+    plain [(attr * text)] spans. *)
+val highlight_text_with_scopes
+  :  t
+  -> lang:string option
+  -> text:string
+  -> scoped_span list list
+
 (** [highlight_text_with_info] is like {!highlight_text} but also returns
     diagnostic information describing whether a fallback occurred.
 
@@ -146,3 +165,10 @@ val highlight_text_with_info
   -> lang:string option
   -> text:string
   -> span list list * info
+
+(** Like {!highlight_text_with_info}, but returns scope-preserving spans. *)
+val highlight_text_with_scopes_with_info
+  :  t
+  -> lang:string option
+  -> text:string
+  -> scoped_span list list * info

--- a/lib/chat_tui/markdown_fences.mli
+++ b/lib/chat_tui/markdown_fences.mli
@@ -57,18 +57,17 @@ type inline =
   | Inline_text of string
   | Inline_code of string
 
-(** [split_inline s] scans [s] for inline code spans delimited by single
-    backticks and returns an alternating sequence of [Inline_text] and
-    [Inline_code].
+(** [split_inline s] scans [s] for inline code spans delimited by backticks
+    and returns an alternating sequence of [Inline_text] and [Inline_code].
 
     Behaviour and limitations:
-    - Only single backticks are recognized; backtick escaping and multi-
-      backtick delimiters are not supported.
+    - Backtick runs of length [n >= 1] are recognized, and a code span is
+      formed by the next run with at least [n] consecutive backticks. (Only
+      [n] backticks are consumed as the delimiter; any remaining backticks are
+      treated as normal text.)
+    - A backtick preceded by a backslash is treated as a literal character and
+      does not start or end a code span.
     - Nesting is not supported.
-    - If a closing backtick is missing, the unterminated code content is
-      treated as plain text, and the opening backtick is dropped.
-    - Known issue: characters captured inside a closed code span are also
-      accumulated into the surrounding [Inline_text] buffer, which can lead to
-      duplication in the returned list (e.g. ["a ", `b`, "b c"]). Callers
-      should account for this until the implementation is fixed. *)
+    - If a closing delimiter is missing, the opening delimiter is treated as
+      plain text (it is not dropped). *)
 val split_inline : string -> inline list

--- a/lib/chat_tui/renderer_component_message.mli
+++ b/lib/chat_tui/renderer_component_message.mli
@@ -52,3 +52,20 @@ val render_header_line
   -> role:string
   -> hi_engine:Highlight_tm_engine.t
   -> Notty.I.t
+
+(** [should_drop_markdown_delimiter ~scopes ~text] returns [true] when a
+    TextMate-tokenised segment represents only a delimiter run for bold/italic
+    or inline code and should therefore be hidden from the rendered output.
+
+    This is exposed primarily for unit tests and debugging of markdown
+    marker suppression. *)
+val should_drop_markdown_delimiter : scopes:string list -> text:string -> bool
+
+(** [suppress_markdown_delimiters spans] filters out delimiter segments from a
+    list of scope-preserving spans.
+
+    This is exposed primarily for unit tests and debugging of markdown marker
+    suppression. *)
+val suppress_markdown_delimiters
+  :  Highlight_tm_engine.scoped_span list
+  -> Highlight_tm_engine.scoped_span list

--- a/lib/chat_tui/type_ahead_provider.ml
+++ b/lib/chat_tui/type_ahead_provider.ml
@@ -52,16 +52,6 @@ let render_history_for_prompt (items : Res.Item.t list) : string =
       (match content with
        | { text; _ } :: _ -> Some (sprintf "assistant: %s" text)
        | _ -> None)
-    | Function_call { name; arguments; call_id; _ } ->
-      sprintf "Function call (%s): %s(%s)" call_id name arguments |> Some
-    | Custom_tool_call { name; input; call_id; _ } ->
-      sprintf "Custom tool call (%s): %s(%s)" call_id name input |> Some
-    | Function_call_output { call_id; output; _ } ->
-      let output = string_of_tool_output output in
-      sprintf "Function call output (%s): %s" call_id output |> Some
-    | Custom_tool_call_output { call_id; output; _ } ->
-      let output = string_of_tool_output output in
-      sprintf "Custom tool call output (%s): %s" call_id output |> Some
     | _ -> None
   in
   items

--- a/test/chat_tui_highlight_tm_engine_scopes_test.ml
+++ b/test/chat_tui_highlight_tm_engine_scopes_test.ml
@@ -1,0 +1,53 @@
+open Core
+open Expect_test_helpers_core
+
+let%expect_test "highlight_text_with_scopes preserves punctuation scopes per segment" =
+  let reg = Chat_tui.Highlight_tm_loader.create_registry () in
+  let grammar =
+    Jsonaf.parse
+      {|{
+          "name": "tiny",
+          "scopeName": "source.tiny",
+          "fileTypes": ["tiny"],
+          "patterns": [
+            { "name": "punctuation.definition.raw.tiny", "match": "`+" },
+            { "name": "punctuation.definition.bold.tiny", "match": "\\*\\*" },
+            { "name": "punctuation.definition.italic.tiny", "match": "\\*" }
+          ]
+        }|}
+    |> Or_error.ok_exn
+  in
+  Chat_tui.Highlight_tm_loader.add_grammar_jsonaf reg grammar |> Or_error.ok_exn;
+  let engine =
+    Chat_tui.Highlight_tm_engine.create ~theme:Chat_tui.Highlight_theme.github_dark
+    |> Chat_tui.Highlight_tm_engine.with_registry ~registry:reg
+  in
+  let lines =
+    Chat_tui.Highlight_tm_engine.highlight_text_with_scopes
+      engine
+      ~lang:(Some "tiny")
+      ~text:"**bold**\n`code`"
+  in
+  let has_prefix scopes prefix =
+    List.exists scopes ~f:(fun s -> String.is_prefix s ~prefix)
+  in
+  let simplified =
+    List.map lines ~f:(fun spans ->
+      List.map spans ~f:(fun { Chat_tui.Highlight_tm_engine.text; scopes; _ } ->
+        ( text
+        , has_prefix scopes "punctuation.definition.bold"
+        , has_prefix scopes "punctuation.definition.italic"
+        , has_prefix scopes "punctuation.definition.raw" )))
+  in
+  print_s [%sexp (simplified : (string * bool * bool * bool) list list)];
+  [%expect
+    {|
+    (((**   true  false false)
+      (bold false false false)
+      (**   true  false false))
+     ((`    false false true)
+      (code false false false)
+      (`    false false true)))
+    |}]
+;;
+

--- a/test/chat_tui_highlight_tm_engine_tokenize_error_test.ml
+++ b/test/chat_tui_highlight_tm_engine_tokenize_error_test.ml
@@ -1,0 +1,85 @@
+open Core
+open Expect_test_helpers_core
+
+let fallback_to_string = function
+  | None -> "None"
+  | Some Chat_tui.Highlight_tm_engine.No_registry -> "No_registry"
+  | Some (Chat_tui.Highlight_tm_engine.Unknown_language l) ->
+    "Unknown_language(" ^ l ^ ")"
+  | Some Chat_tui.Highlight_tm_engine.Tokenize_error -> "Tokenize_error"
+;;
+
+let%expect_test "highlight_text_with_info reports Tokenize_error and falls back for all lines" =
+  let reg = Chat_tui.Highlight_tm_loader.create_registry () in
+  let grammar =
+    Jsonaf.parse
+      {|{
+          "name": "bad",
+          "scopeName": "source.bad",
+          "patterns": [ { "include": "#missing" } ],
+          "repository": {}
+        }|}
+    |> Or_error.ok_exn
+  in
+  Chat_tui.Highlight_tm_loader.add_grammar_jsonaf reg grammar |> Or_error.ok_exn;
+  let engine =
+    Chat_tui.Highlight_tm_engine.create ~theme:Chat_tui.Highlight_theme.github_dark
+    |> Chat_tui.Highlight_tm_engine.with_registry ~registry:reg
+  in
+  let spans, info =
+    Chat_tui.Highlight_tm_engine.highlight_text_with_info
+      engine
+      ~lang:(Some "bad")
+      ~text:"hi\nthere"
+  in
+  let fallback = fallback_to_string info.fallback in
+  let lines = List.map spans ~f:(List.map ~f:snd) in
+  print_s [%sexp { fallback : string; lines : string list list }];
+  [%expect
+    {|
+    ((fallback Tokenize_error)
+     (lines (
+       (hi)
+       (there))))
+    |}]
+;;
+
+let%expect_test "highlight_text_with_scopes_with_info also reports Tokenize_error and falls back" =
+  let reg = Chat_tui.Highlight_tm_loader.create_registry () in
+  let grammar =
+    Jsonaf.parse
+      {|{
+          "name": "bad",
+          "scopeName": "source.bad",
+          "patterns": [ { "include": "#missing" } ],
+          "repository": {}
+        }|}
+    |> Or_error.ok_exn
+  in
+  Chat_tui.Highlight_tm_loader.add_grammar_jsonaf reg grammar |> Or_error.ok_exn;
+  let engine =
+    Chat_tui.Highlight_tm_engine.create ~theme:Chat_tui.Highlight_theme.github_dark
+    |> Chat_tui.Highlight_tm_engine.with_registry ~registry:reg
+  in
+  let spans, info =
+    Chat_tui.Highlight_tm_engine.highlight_text_with_scopes_with_info
+      engine
+      ~lang:(Some "bad")
+      ~text:"hi\nthere"
+  in
+  let fallback = fallback_to_string info.fallback in
+  let lines =
+    List.map spans ~f:(fun spans ->
+      List.map spans ~f:(fun { Chat_tui.Highlight_tm_engine.text; scopes; _ } ->
+        text, scopes))
+  in
+  print_s [%sexp { fallback : string; lines : (string * string list) list list }];
+  [%expect
+    {|
+    ((fallback Tokenize_error)
+     (lines (
+       ((hi    ()))
+       ((there ())))))
+    |}]
+;;
+

--- a/test/chat_tui_markdown_marker_suppression_test.ml
+++ b/test/chat_tui_markdown_marker_suppression_test.ml
@@ -1,0 +1,260 @@
+open Core
+open Expect_test_helpers_core
+
+let fallback_to_string = function
+  | None -> "None"
+  | Some Chat_tui.Highlight_tm_engine.No_registry -> "No_registry"
+  | Some (Chat_tui.Highlight_tm_engine.Unknown_language l) ->
+    "Unknown_language(" ^ l ^ ")"
+  | Some Chat_tui.Highlight_tm_engine.Tokenize_error -> "Tokenize_error"
+;;
+
+let markdown_test_engine () : Chat_tui.Highlight_tm_engine.t =
+  let open Chat_tui in
+  let grammar =
+    {|{
+      "scopeName": "text.html.markdown",
+      "name": "Markdown",
+      "fileTypes": ["md"],
+      "patterns": [
+        {
+          "match": "^\\*\\s+",
+          "name": "punctuation.definition.list.begin.markdown"
+        },
+        {
+          "name": "markup.bold.markdown",
+          "begin": "\\*\\*",
+          "beginCaptures": { "0": { "name": "punctuation.definition.bold.markdown" } },
+          "end": "\\*\\*",
+          "endCaptures": { "0": { "name": "punctuation.definition.bold.markdown" } },
+          "patterns": [
+            {
+              "name": "markup.italic.markdown",
+              "begin": "\\*",
+              "beginCaptures": { "0": { "name": "punctuation.definition.italic.markdown" } },
+              "end": "\\*",
+              "endCaptures": { "0": { "name": "punctuation.definition.italic.markdown" } }
+            }
+          ]
+        },
+        {
+          "name": "markup.italic.markdown",
+          "begin": "\\*",
+          "beginCaptures": { "0": { "name": "punctuation.definition.italic.markdown" } },
+          "end": "\\*",
+          "endCaptures": { "0": { "name": "punctuation.definition.italic.markdown" } }
+        },
+        {
+          "name": "markup.inline.raw.string.markdown",
+          "begin": "`",
+          "beginCaptures": { "0": { "name": "punctuation.definition.raw.markdown" } },
+          "end": "`",
+          "endCaptures": { "0": { "name": "punctuation.definition.raw.markdown" } }
+        }
+      ]
+    }|}
+  in
+  let reg = Highlight_tm_loader.create_registry () in
+  grammar
+  |> Jsonaf.parse
+  |> Or_error.ok_exn
+  |> Highlight_tm_loader.add_grammar_jsonaf reg
+  |> Or_error.ok_exn;
+  Highlight_tm_engine.create ~theme:Highlight_theme.github_dark
+  |> Highlight_tm_engine.with_registry ~registry:reg
+;;
+
+let render_to_string ~(w : int) ~(h : int) (img : Notty.I.t) : string =
+  let buf = Buffer.create 4096 in
+  Notty.Render.to_buffer buf Notty.Cap.dumb (0, 0) (w, h) img;
+  Buffer.contents buf
+;;
+
+let render_message_to_string ~(width : int) ~(hi_engine : Chat_tui.Highlight_tm_engine.t) ~text =
+  let img =
+    Chat_tui.Renderer_component_message.render_message
+      ~width
+      ~selected:false
+      ~tool_output:None
+      ~role:"user"
+      ~text
+      ~hi_engine
+  in
+  render_to_string ~w:width ~h:(Notty.I.height img) img
+;;
+
+let%expect_test "should_drop_markdown_delimiter: unit cases" =
+  let open Chat_tui.Renderer_component_message in
+  let cases =
+    [ [ "punctuation.definition.bold.markdown" ], "**", true
+    ; [ "punctuation.definition.italic.markdown" ], "*", true
+    ; [ "punctuation.definition.raw.markdown" ], "`", true
+    ; [ "punctuation.definition.raw.markdown" ], "``", true
+    ; [ "markup.bold.markdown"; "punctuation.definition.bold.markdown" ], "**", true
+    ; [ "punctuation.definition.list.begin.markdown" ], "*", false
+    ; [ "punctuation.definition.italic.markdown" ], "*a", false
+    ; [ "punctuation.definition.italic.markdown" ], "", false
+    ; [ "punctuation.definition.italic.markdown" ], "_", true
+    ; [ "punctuation.definition.bold.markdown" ], "__", true
+    ]
+  in
+  List.iter cases ~f:(fun (scopes, text, expected) ->
+    let got = should_drop_markdown_delimiter ~scopes ~text in
+    printf !"%s %S -> %b\n" (String.concat ~sep:"," scopes) text got;
+    require
+      [%here]
+      (Bool.equal got expected)
+      ~if_false_then_print_s:
+        (lazy [%message "unexpected result" (scopes : string list) (text : string) (got : bool) (expected : bool)]));
+  [%expect
+    {|
+    punctuation.definition.bold.markdown "**" -> true
+    punctuation.definition.italic.markdown "*" -> true
+    punctuation.definition.raw.markdown "`" -> true
+    punctuation.definition.raw.markdown "``" -> true
+    markup.bold.markdown,punctuation.definition.bold.markdown "**" -> true
+    punctuation.definition.list.begin.markdown "*" -> false
+    punctuation.definition.italic.markdown "*a" -> false
+    punctuation.definition.italic.markdown "" -> false
+    punctuation.definition.italic.markdown "_" -> true
+    punctuation.definition.bold.markdown "__" -> true
+    |}]
+;;
+
+let%expect_test "scope-aware suppression removes markers and preserves content (scoped spans)" =
+  let open Chat_tui in
+  let hi_engine = markdown_test_engine () in
+  let text =
+    String.concat
+      ~sep:"\n"
+      [ "**BOLD** then *ITALIC* and `CODE`."
+      ; "* ITEM"
+      ; "**OUTER *INNER* OUTER**"
+      ]
+  in
+  let lines, info =
+    Highlight_tm_engine.highlight_text_with_scopes_with_info
+      hi_engine
+      ~lang:(Some "markdown")
+      ~text
+  in
+  printf "fallback=%s\n" (fallback_to_string info.fallback);
+  let lines = List.map lines ~f:Renderer_component_message.suppress_markdown_delimiters in
+  let line_text spans =
+    spans
+    |> List.map ~f:(fun s -> s.Chat_tui.Highlight_tm_engine.text)
+    |> String.concat
+  in
+  let rendered = lines |> List.map ~f:line_text |> String.concat ~sep:"\n" in
+  print_endline rendered;
+  let line0 = List.nth_exn lines 0 in
+  let line2 = List.nth_exn lines 2 in
+  let find_span_exn spans ~substring =
+    List.find_exn spans ~f:(fun s ->
+      String.is_substring s.Chat_tui.Highlight_tm_engine.text ~substring)
+  in
+  let bold = find_span_exn line0 ~substring:"BOLD" in
+  let italic = find_span_exn line0 ~substring:"ITALIC" in
+  let code = find_span_exn line0 ~substring:"CODE" in
+  let inner = find_span_exn line2 ~substring:"INNER" in
+  let has_scope scopes scope = List.exists scopes ~f:(String.equal scope) in
+  let has_prefix scopes ~prefix = List.exists scopes ~f:(String.is_prefix ~prefix) in
+  printf
+    "bold: markup=%b punct=%b\n"
+    (has_scope bold.Chat_tui.Highlight_tm_engine.scopes "markup.bold.markdown")
+    (has_prefix
+       bold.Chat_tui.Highlight_tm_engine.scopes
+       ~prefix:"punctuation.definition.bold");
+  printf
+    "italic: markup=%b punct=%b\n"
+    (has_scope italic.Chat_tui.Highlight_tm_engine.scopes "markup.italic.markdown")
+    (has_prefix
+       italic.Chat_tui.Highlight_tm_engine.scopes
+       ~prefix:"punctuation.definition.italic");
+  printf
+    "code: markup=%b punct=%b\n"
+    (has_scope
+       code.Chat_tui.Highlight_tm_engine.scopes
+       "markup.inline.raw.string.markdown")
+    (has_prefix code.Chat_tui.Highlight_tm_engine.scopes ~prefix:"punctuation.definition.raw");
+  printf
+    "inner: bold=%b italic=%b\n"
+    (has_scope inner.Chat_tui.Highlight_tm_engine.scopes "markup.bold.markdown")
+    (has_scope inner.Chat_tui.Highlight_tm_engine.scopes "markup.italic.markdown");
+  [%expect
+    {|
+    fallback=None
+    BOLD then ITALIC and CODE.
+    * ITEM
+    OUTER INNER OUTER
+    bold: markup=true punct=false
+    italic: markup=true punct=false
+    code: markup=true punct=false
+    inner: bold=true italic=true
+    |}]
+;;
+
+let%expect_test "renderer output: markers are hidden (scoped + fallback engines)" =
+  let open Chat_tui in
+  let text_basic =
+    String.concat
+      ~sep:"\n"
+      [ "**BOLD** then *ITALIC* and `CODE`."
+      ; "* ITEM"
+      ; "**OUTER *INNER* OUTER**"
+      ]
+  in
+  let text_multicode = "``CODE`WITH`BACKTICKS``" in
+  let width = 140 in
+  let check_basic ~which ~hi_engine =
+    let s = render_message_to_string ~width ~hi_engine ~text:text_basic in
+    let has sub = String.is_substring s ~substring:sub in
+    printf
+      "%s basic: **BOLD**=%b *ITALIC*=%b `CODE`=%b *INNER*=%b\n"
+      which
+      (has "**BOLD**")
+      (has "*ITALIC*")
+      (has "`CODE`")
+      (has "*INNER*");
+    String.split_lines s
+    |> List.map ~f:String.strip
+    |> List.filter ~f:(fun line ->
+      String.is_substring line ~substring:"BOLD"
+      || String.is_substring line ~substring:"ITALIC"
+      || String.is_substring line ~substring:"CODE"
+      || String.is_substring line ~substring:"ITEM"
+      || String.is_substring line ~substring:"OUTER"
+      || String.is_substring line ~substring:"INNER")
+    |> List.iter ~f:(fun line -> printf "%s basic: %s\n" which line)
+  in
+  let check_multicode_fallback () =
+    let hi_engine = Highlight_tm_engine.create ~theme:Highlight_theme.github_dark in
+    let s = render_message_to_string ~width ~hi_engine ~text:text_multicode in
+    let has sub = String.is_substring s ~substring:sub in
+    printf "fallback multicode: has_delims=%b has_content=%b\n" (has "``") (has "CODE`WITH`BACKTICKS");
+    String.split_lines s
+    |> List.map ~f:String.strip
+    |> List.filter ~f:(fun line ->
+      String.is_substring line ~substring:"CODE" || String.is_substring line ~substring:"BACKTICKS")
+    |> List.iter ~f:(fun line -> printf "fallback multicode: %s\n" line)
+  in
+  check_basic ~which:"scoped" ~hi_engine:(markdown_test_engine ());
+  check_basic
+    ~which:"fallback"
+    ~hi_engine:(Highlight_tm_engine.create ~theme:Highlight_theme.github_dark);
+  check_multicode_fallback ();
+  [%expect
+    {|
+    scoped basic: **BOLD**=false *ITALIC*=false `CODE`=false *INNER*=false
+    scoped basic: BOLD then ITALIC and CODE.
+    scoped basic: * ITEM
+    scoped basic: OUTER INNER OUTER
+    fallback basic: **BOLD**=false *ITALIC*=false `CODE`=false *INNER*=false
+    fallback basic: BOLD then ITALIC and CODE.
+    fallback basic: * ITEM
+    fallback basic: OUTER INNER OUTER
+    fallback multicode: has_delims=false has_content=true
+    fallback multicode: CODE`WITH`BACKTICKS
+    |}]
+;;
+

--- a/test/dune
+++ b/test/dune
@@ -310,6 +310,42 @@
   (pps ppx_jane ppx_expect)))
 
 ;; ---------------------------------------------------------------------------
+;; Chat-TUI – Highlight engine scope-preserving API tests
+;; ---------------------------------------------------------------------------
+
+(library
+ (name chat_tui_highlight_tm_engine_scopes_test)
+ (modules chat_tui_highlight_tm_engine_scopes_test)
+ (libraries core expect_test_helpers_core jsonaf chat_tui)
+ (inline_tests)
+ (preprocess
+  (pps ppx_jane ppx_expect)))
+
+;; ---------------------------------------------------------------------------
+;; Chat-TUI – Highlight engine Tokenize_error fallback reporting tests
+;; ---------------------------------------------------------------------------
+
+(library
+ (name chat_tui_highlight_tm_engine_tokenize_error_test)
+ (modules chat_tui_highlight_tm_engine_tokenize_error_test)
+ (libraries core expect_test_helpers_core jsonaf chat_tui)
+ (inline_tests)
+ (preprocess
+  (pps ppx_jane ppx_expect)))
+
+;; ---------------------------------------------------------------------------
+;; Chat-TUI – Markdown marker suppression tests
+;; ---------------------------------------------------------------------------
+
+(library
+ (name chat_tui_markdown_marker_suppression_test)
+ (modules chat_tui_markdown_marker_suppression_test)
+ (libraries core expect_test_helpers_core notty chat_tui)
+ (inline_tests)
+ (preprocess
+  (pps ppx_jane ppx_expect)))
+
+;; ---------------------------------------------------------------------------
 ;; Chat-TUI – Type-ahead reducer debounce / stale-result tests
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### Summary
- Improve inline backtick parsing (multi-backtick spans + escaped backticks)
- Preserve TextMate scopes in highlight output so markdown delimiter punctuation can be filtered
- Render markdown without showing **, __, *, _, and backtick marker runs while keeping styling

### Tests
- Added new expect tests for:
  - scope preservation
  - tokenize-error fallback reporting
  - markdown marker suppression

### Notes
- Increases tool timeout to 180s.
- Removes `dune-workspace`.
